### PR TITLE
Add dalink sponsor link to FUNDING custom list

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://boosty.to/0xffff']
+custom: ['https://dalink.to/b4tman1', 'https://boosty.to/0xffff']


### PR DESCRIPTION
### Motivation
- Add `https://dalink.to/b4tman1` as an additional project sponsorship option and place it first in the `custom` list so it appears with highest priority.

### Description
- Update ` .github/FUNDING.yml` to set `custom: ['https://dalink.to/b4tman1', 'https://boosty.to/0xffff']` so the new sponsorship link is listed first.

### Testing
- Verified the updated file contents with `sed -n '1,200p' .github/FUNDING.yml`, inspected the change with `git diff -- .github/FUNDING.yml`, checked repository status with `git status --short`, and listed the file with `nl -ba .github/FUNDING.yml`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3def77764832e89b73c5831440b4a)